### PR TITLE
Bug fix in fuse generator

### DIFF
--- a/saltax/contexts.py
+++ b/saltax/contexts.py
@@ -246,7 +246,7 @@ def xenonnt_salted_fuse(
             log.info("Loaded instructions from file", instr_file_name)
         except:
             log.info(f"Instruction file {instr_file_name} not found. Generating instructions...")
-            instr = generator_func(runid=runid, **kwargs)
+            instr = generator_func(runid=runid, recoil=recoil, **kwargs)
             pd.DataFrame(instr).to_csv(instr_file_name, index=False)
             log.info(f"Instructions saved to {instr_file_name}")
 


### PR DESCRIPTION
Before this PR, we are somehow always simulating ER type in saltax when using fuse! The problem here is the missing `recoil` in `generator_func`. 

This leads to the always-beta nest type:
```
vim 051911-0-flat-0.2_45-all-100.csv

event_number,type,time,x,y,z,amp,recoil,e_dep,tot_e,g4id,vol_id,local_field,n_excitons,x_pri,y_pri,z_pri
1,1,1681822424117999872,-46.468105,16.676464,-65.51044,287,8,5.1959395,0.0,0,0,21.985272256943297,31,0.0,0.0,0.0
1,2,1681822424117999872,-46.468105,16.676464,-65.51044,132,8,5.1959395,0.0,0,0,21.985272256943297,31,0.0,0.0,0.0
2,1,1681822424127999872,-36.150017,34.574623,-104.82069,595,8,12.245673,0.0,0,0,21.803115082164446,80,0.0,0.0,0.0
2,2,1681822424127999872,-36.150017,34.574623,-104.82069,270,8,12.245673,0.0,0,0,21.803115082164446,80,0.0,0.0,0.0
```