### PR TITLE
Force unblind

### DIFF
--- a/jobs/job.py
+++ b/jobs/job.py
@@ -101,6 +101,7 @@ def create_context(settings, runid):
         simu_mode=settings["simu_mode"],
         rate=settings["rate"] if settings["rate"] else None,
         en_range=settings["en_range"] if settings["en_range"] else None,
+        unblind=True
     )
     for d in settings["storage_to_patch"]:
         if d:

--- a/saltax/contexts.py
+++ b/saltax/contexts.py
@@ -424,6 +424,7 @@ def fxenonnt(
     generator_name="flat",
     recoil=8,
     simu_mode="all",
+    unblind=True,
     **kwargs,
 ):
     """United strax context for XENONnT data, simulation, or salted data. Based
@@ -447,6 +448,7 @@ def fxenonnt(
     :param generator_name: Instruction mode to use, defaults to 'flat'
     :param recoil: NEST recoil type, defaults to 8 (beta ER)
     :param simu_mode: 's1', 's2', or 'all'. Defaults to 'all'
+    :param unblind: Whether to bypass any kind of blinding, defaults to True
     :param kwargs: Extra options to pass to strax.Context or generator,
         and rate/en_range etc for generator
     :return: strax context
@@ -461,7 +463,7 @@ def fxenonnt(
         validate_runid(runid)
         log.warning("Welcome to computation mode which only works for run %s!" % (runid))
 
-    return xenonnt_salted_fuse(
+    st = xenonnt_salted_fuse(
         runid=runid,
         saltax_mode=saltax_mode,
         output_folder=output_folder,
@@ -475,6 +477,10 @@ def fxenonnt(
         simu_mode=simu_mode,
         **kwargs,
     )
+    if unblind:
+        st.set_config(dict(event_info_function="disabled"))
+
+    return st
 
 
 def sxenonnt(
@@ -489,6 +495,7 @@ def sxenonnt(
     generator_name="flat",
     recoil=7,
     simu_mode="all",
+    unblind=True,
     **kwargs,
 ):
     """United strax context for XENONnT data, simulation, or salted data. Based
@@ -514,6 +521,7 @@ def sxenonnt(
     :param recoil: (for simulation) NEST recoil type, defaults to 7
         (beta ER)
     :param simu_mode: 's1', 's2', or 'all'. Defaults to 'all'
+    :param unblind: Whether to bypass any kind of blinding, defaults to True
     :param kwargs: Additional kwargs to pass
     :return: strax context
     """
@@ -527,7 +535,7 @@ def sxenonnt(
         validate_runid(runid)
         log.warning("Welcome to computation mode which only works for run %s!" % (runid))
 
-    return xenonnt_salted_wfsim(
+    st = xenonnt_salted_wfsim(
         runid=runid,
         output_folder=output_folder,
         corrections_version=corrections_version,
@@ -541,3 +549,7 @@ def sxenonnt(
         saltax_mode=saltax_mode,
         **kwargs,
     )
+    if unblind:
+        st.set_config(dict(event_info_function="disabled"))
+    
+    return st


### PR DESCRIPTION
BE VERY CAUTIOUS. This functionality will force unblind the sprinkled and simulation datasets when `unblind` is on.