### PR TITLE
Constrain the strax(en) version lower than v2.0.0(v3.0.0)

### DIFF
--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -11,8 +11,8 @@ on:
     types: [created]
   pull_request:
   push:
-   branches:
-    - main
+    branches:
+      - main
 
 jobs:
   update:
@@ -48,7 +48,6 @@ jobs:
         uses: py-actions/py-dependency-install@v2
       - name: Install requirements
         run: |
-          pip install -r extra_requirements/requirements-tests.txt
           pip install ./cutax
       - name: Install saltax
         run: python setup.py develop

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ generated/
 
 # strax
 *strax_data/
+*resource_cache/
+*fuse_data/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/extra_requirements/requirements-tests.txt
+++ b/extra_requirements/requirements-tests.txt
@@ -1,5 +1,0 @@
-# File for the requirements of saltax with the automated tests
-git+https://github.com/AxFoundation/strax
-git+https://github.com/XENONnT/straxen
-pytest-xdist
-xedocs

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-strax
-straxen
+strax<2.0.0
+straxen<3.0.0
 wfsim>=1.2.2
 scipy
 numpy


### PR DESCRIPTION
_Before you submit this PR: make sure to put all operations-related information in a wiki-note, a PR should be about code and is publicly accessible_

## What does the code in this PR do / what does it improve?

Because the updates in strax(en) v2.0.0(v3.0.0) greatly changed the peaklets plugin, we have to update the saltax code to make it compatible with both strax 1 and strax 2 (straxen 2 and straxen 3).

## Can you briefly describe how it works?

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [ ] _Add an appropriate tag to this PR_
  - [ ] _Update the docstring(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the open issues on github?_

### _Notes on testing_
 - _Until the automated tests pass, please mark the PR as a draft._
 - _On the XENONnT fork we test with database access, on private forks there is no database access for security considerations._

All _italic_ comments can be removed from this template.
