### PR TITLE
Rename `fxenonnt` to `sxenonnt`

### DIFF
--- a/jobs/job.py
+++ b/jobs/job.py
@@ -112,7 +112,7 @@ def create_context(settings, runid):
 def get_context_function(package):
     """Return the context function for the given package."""
     if package == "fuse":
-        return saltax.contexts.fxenonnt
+        return saltax.contexts.sxenonnt
     raise ValueError("Invalid package name %s" % package)
 
 

--- a/notebooks/example_minimal.ipynb
+++ b/notebooks/example_minimal.ipynb
@@ -61,9 +61,9 @@
    "source": [
     "# You only need runid in context when you need to compute raw_records_simu\n",
     "# salt mode: reconstruction from a mixture of data and simulation\n",
-    "st_salt = saltax.contexts.fxenonnt(runid=37119, saltax_mode=\"salt\")\n",
+    "st_salt = saltax.contexts.sxenonnt(runid=37119, saltax_mode=\"salt\")\n",
     "# simu mode: reconstruction from simulation only\n",
-    "st_simu = saltax.contexts.fxenonnt(runid=37119, saltax_mode=\"simu\")"
+    "st_simu = saltax.contexts.sxenonnt(runid=37119, saltax_mode=\"simu\")"
    ]
   },
   {
@@ -81,7 +81,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "??saltax.contexts.fxenonnt"
+    "??saltax.contexts.sxenonnt"
    ]
   },
   {

--- a/saltax/README.md
+++ b/saltax/README.md
@@ -7,4 +7,4 @@ Core functions of `saltax`.
 - `instructions`: `fuse` CSV instruction related, including event generators.
 - `match`: tools to match salted truth and reconstucted signals.
 - `plugins`: `straxen`-like plugins for salting, equivalently from `raw_records` to `peaklets`.
-- `contexts.py`: `strax` context for `saltax`. You will want to use `fxenonnt` (`fuse` based simulation) as default context.
+- `contexts.py`: `strax` context for `saltax`. You will want to use `sxenonnt` as default context.


### PR DESCRIPTION
The context based on fuse is developed after the context based on wfsim. The naming fashion in `saltax` is to prefix an `s` or `S` in front of the modified straxen / fuse class, like `SPMTResponseAndDAQ` and `SChunkCsvInput`. But for historical reasons (fuse after wfsim), fuse context was named `fxenonnt`.

So it is natural to rename `fxenonnt` to `sxenonnt` after `wfsim` is removed in https://github.com/XENONnT/saltax/pull/160