### PR TITLE
Fix `classifiers` in `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 classifiers = [
   "Development Status :: 3 - Alpha",
-  "License :: MIT License",
+  "License :: OSI Approved :: MIT License",
   "Natural Language :: English",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
The issue blocked https://github.com/XENONnT/saltax/actions/runs/15988492518